### PR TITLE
Claude Code MCP Addition Command Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Advanced configuration (environment variables, network modes)
   - Security considerations for Claude Code integration
 
+### Fixed
+- **Claude Code CLI command syntax** - Added `--` separator to prevent `-i` flag parsing error
+  - Corrected command: `claude mcp add --transport stdio kali-mcp-server docker -- run -i ...`
+  - Prevents "unknown option '-i'" error when adding MCP server
+
 ### Documentation
 - Complete guide for integrating Kali MCP server with Claude Code CLI
 - Instructions for managed MCP config and project-scope `.mcp.json`
 - Container lifecycle management and monitoring
 - Verification steps and common error solutions
+- Added note explaining `--` separator usage in CLI commands
 
 ## [1.0.5] - 2025-10-08
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ For Claude Code CLI integration, see the [Claude Code Integration Guide](docs/CL
 
 **Quick setup:**
 ```bash
-claude mcp add --transport stdio kali-mcp-server docker run -i kali-mcp-server python -m kali_mcp_server --transport stdio
+# Add the MCP server (note: use -- to separate args)
+claude mcp add --transport stdio kali-mcp-server docker -- run -i kali-mcp-server python -m kali_mcp_server --transport stdio
+
+# Verify it was added
+claude mcp list
 ```
 
 ## 🛠️ Available MCP Tools

--- a/docs/CLAUDE_CODE.md
+++ b/docs/CLAUDE_CODE.md
@@ -22,8 +22,10 @@ Claude Code is Anthropic's official CLI tool that brings Claude's capabilities t
 Add the Kali MCP server using the Claude Code CLI:
 
 ```bash
-claude mcp add --transport stdio kali-mcp-server docker run -i kali-mcp-server python -m kali_mcp_server --transport stdio
+claude mcp add --transport stdio kali-mcp-server docker -- run -i kali-mcp-server python -m kali_mcp_server --transport stdio
 ```
+
+**Note:** The `--` separator tells the CLI to treat everything after `docker` as arguments, preventing `-i` from being interpreted as a flag.
 
 **Verify the configuration:**
 ```bash


### PR DESCRIPTION
This pull request addresses a command-line parsing issue when integrating the Kali MCP server with the Claude Code CLI. The main change is the addition of a `--` separator in CLI commands to prevent argument parsing errors, particularly with the `-i` flag. Documentation has also been updated to reflect this fix and to clarify usage for users.

### Bug fix and CLI usage clarification

* Added a `--` separator to the `claude mcp add` command to prevent the `-i` flag from being misinterpreted, resolving the "unknown option '-i'" error when adding an MCP server. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R92) [[3]](diffhunk://#diff-2685be7227a130b6c654d3638452d4d5c492a609c2da3d1303a03dd5cef86d3fL25-R29)

### Documentation improvements

* Updated the `CHANGELOG.md`, `README.md`, and `docs/CLAUDE_CODE.md` to include the corrected command syntax and an explanatory note about the `--` separator. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R92) [[3]](diffhunk://#diff-2685be7227a130b6c654d3638452d4d5c492a609c2da3d1303a03dd5cef86d3fL25-R29)